### PR TITLE
fix: manage version bumping for v1p1beta1 artifacts

### DIFF
--- a/versions.txt
+++ b/versions.txt
@@ -2,9 +2,11 @@
 # module:released-version:current-version
 
 proto-google-cloud-asset-v1:0.82.0:0.82.1-SNAPSHOT
+proto-google-cloud-asset-v1p1beta1:0.82.0:0.82.1-SNAPSHOT
 proto-google-cloud-asset-v1p2beta1:0.82.0:0.82.1-SNAPSHOT
 proto-google-cloud-asset-v1beta1:0.82.0:0.82.1-SNAPSHOT
 grpc-google-cloud-asset-v1:0.82.0:0.82.1-SNAPSHOT
 grpc-google-cloud-asset-v1beta1:0.82.0:0.82.1-SNAPSHOT
+grpc-google-cloud-asset-v1p1beta1:0.82.0:0.82.1-SNAPSHOT
 grpc-google-cloud-asset-v1p2beta1:0.82.0:0.82.1-SNAPSHOT
 google-cloud-asset:0.117.0-beta:0.117.1-beta-SNAPSHOT


### PR DESCRIPTION
Our last release did not bump the v1p1beta1 artifact version because we didn't have that version in the `versions.txt` manifest