### PR TITLE
chore: Migrate asset synth.py to bazel

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ If you are using Maven with [BOM][libraries-bom], add this to your pom.xml file
     </dependency>
   </dependencies>
 </dependencyManagement>
+
 <dependencies>
   <dependency>
     <groupId>com.google.cloud</groupId>
     <artifactId>google-cloud-asset</artifactId>
   </dependency>
-</dependencies>
+
 ```
 
 [//]: # ({x-version-update-start:google-cloud-asset:released})
@@ -41,6 +42,7 @@ If you are using Maven without BOM, add this to your dependencies:
   <artifactId>google-cloud-asset</artifactId>
   <version>1.1.0</version>
 </dependency>
+
 ```
 
 If you are using Gradle, add this to your dependencies

--- a/grpc-google-cloud-asset-v1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-asset-v1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.1.1 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/asset/v1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-asset-v1/src/main/java/com/google/cloud/asset/v1/AssetServiceGrpc.java
+++ b/grpc-google-cloud-asset-v1/src/main/java/com/google/cloud/asset/v1/AssetServiceGrpc.java
@@ -30,7 +30,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/asset/v1/asset_service.proto")
 public final class AssetServiceGrpc {
 
@@ -39,26 +39,18 @@ public final class AssetServiceGrpc {
   public static final String SERVICE_NAME = "google.cloud.asset.v1.AssetService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getExportAssetsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1.ExportAssetsRequest, com.google.longrunning.Operation>
-      METHOD_EXPORT_ASSETS = getExportAssetsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1.ExportAssetsRequest, com.google.longrunning.Operation>
       getExportAssetsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ExportAssets",
+      requestType = com.google.cloud.asset.v1.ExportAssetsRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1.ExportAssetsRequest, com.google.longrunning.Operation>
       getExportAssetsMethod() {
-    return getExportAssetsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1.ExportAssetsRequest, com.google.longrunning.Operation>
-      getExportAssetsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.asset.v1.ExportAssetsRequest, com.google.longrunning.Operation>
         getExportAssetsMethod;
@@ -72,9 +64,7 @@ public final class AssetServiceGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.asset.v1.AssetService", "ExportAssets"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ExportAssets"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -90,30 +80,20 @@ public final class AssetServiceGrpc {
     return getExportAssetsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchGetAssetsHistoryMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1.BatchGetAssetsHistoryRequest,
-          com.google.cloud.asset.v1.BatchGetAssetsHistoryResponse>
-      METHOD_BATCH_GET_ASSETS_HISTORY = getBatchGetAssetsHistoryMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1.BatchGetAssetsHistoryRequest,
           com.google.cloud.asset.v1.BatchGetAssetsHistoryResponse>
       getBatchGetAssetsHistoryMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchGetAssetsHistory",
+      requestType = com.google.cloud.asset.v1.BatchGetAssetsHistoryRequest.class,
+      responseType = com.google.cloud.asset.v1.BatchGetAssetsHistoryResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1.BatchGetAssetsHistoryRequest,
           com.google.cloud.asset.v1.BatchGetAssetsHistoryResponse>
       getBatchGetAssetsHistoryMethod() {
-    return getBatchGetAssetsHistoryMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1.BatchGetAssetsHistoryRequest,
-          com.google.cloud.asset.v1.BatchGetAssetsHistoryResponse>
-      getBatchGetAssetsHistoryMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.asset.v1.BatchGetAssetsHistoryRequest,
             com.google.cloud.asset.v1.BatchGetAssetsHistoryResponse>
@@ -131,8 +111,7 @@ public final class AssetServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.asset.v1.AssetService", "BatchGetAssetsHistory"))
+                          generateFullMethodName(SERVICE_NAME, "BatchGetAssetsHistory"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -151,26 +130,18 @@ public final class AssetServiceGrpc {
     return getBatchGetAssetsHistoryMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateFeedMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1.CreateFeedRequest, com.google.cloud.asset.v1.Feed>
-      METHOD_CREATE_FEED = getCreateFeedMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1.CreateFeedRequest, com.google.cloud.asset.v1.Feed>
       getCreateFeedMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateFeed",
+      requestType = com.google.cloud.asset.v1.CreateFeedRequest.class,
+      responseType = com.google.cloud.asset.v1.Feed.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1.CreateFeedRequest, com.google.cloud.asset.v1.Feed>
       getCreateFeedMethod() {
-    return getCreateFeedMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1.CreateFeedRequest, com.google.cloud.asset.v1.Feed>
-      getCreateFeedMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.asset.v1.CreateFeedRequest, com.google.cloud.asset.v1.Feed>
         getCreateFeedMethod;
@@ -183,9 +154,7 @@ public final class AssetServiceGrpc {
                       .<com.google.cloud.asset.v1.CreateFeedRequest, com.google.cloud.asset.v1.Feed>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.asset.v1.AssetService", "CreateFeed"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateFeed"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -201,26 +170,18 @@ public final class AssetServiceGrpc {
     return getCreateFeedMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetFeedMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1.GetFeedRequest, com.google.cloud.asset.v1.Feed>
-      METHOD_GET_FEED = getGetFeedMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1.GetFeedRequest, com.google.cloud.asset.v1.Feed>
       getGetFeedMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetFeed",
+      requestType = com.google.cloud.asset.v1.GetFeedRequest.class,
+      responseType = com.google.cloud.asset.v1.Feed.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1.GetFeedRequest, com.google.cloud.asset.v1.Feed>
       getGetFeedMethod() {
-    return getGetFeedMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1.GetFeedRequest, com.google.cloud.asset.v1.Feed>
-      getGetFeedMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.asset.v1.GetFeedRequest, com.google.cloud.asset.v1.Feed>
         getGetFeedMethod;
@@ -233,8 +194,7 @@ public final class AssetServiceGrpc {
                       .<com.google.cloud.asset.v1.GetFeedRequest, com.google.cloud.asset.v1.Feed>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.asset.v1.AssetService", "GetFeed"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetFeed"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -250,26 +210,18 @@ public final class AssetServiceGrpc {
     return getGetFeedMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListFeedsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1.ListFeedsRequest, com.google.cloud.asset.v1.ListFeedsResponse>
-      METHOD_LIST_FEEDS = getListFeedsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1.ListFeedsRequest, com.google.cloud.asset.v1.ListFeedsResponse>
       getListFeedsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListFeeds",
+      requestType = com.google.cloud.asset.v1.ListFeedsRequest.class,
+      responseType = com.google.cloud.asset.v1.ListFeedsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1.ListFeedsRequest, com.google.cloud.asset.v1.ListFeedsResponse>
       getListFeedsMethod() {
-    return getListFeedsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1.ListFeedsRequest, com.google.cloud.asset.v1.ListFeedsResponse>
-      getListFeedsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.asset.v1.ListFeedsRequest, com.google.cloud.asset.v1.ListFeedsResponse>
         getListFeedsMethod;
@@ -283,8 +235,7 @@ public final class AssetServiceGrpc {
                           com.google.cloud.asset.v1.ListFeedsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName("google.cloud.asset.v1.AssetService", "ListFeeds"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListFeeds"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -300,26 +251,18 @@ public final class AssetServiceGrpc {
     return getListFeedsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateFeedMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1.UpdateFeedRequest, com.google.cloud.asset.v1.Feed>
-      METHOD_UPDATE_FEED = getUpdateFeedMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1.UpdateFeedRequest, com.google.cloud.asset.v1.Feed>
       getUpdateFeedMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateFeed",
+      requestType = com.google.cloud.asset.v1.UpdateFeedRequest.class,
+      responseType = com.google.cloud.asset.v1.Feed.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1.UpdateFeedRequest, com.google.cloud.asset.v1.Feed>
       getUpdateFeedMethod() {
-    return getUpdateFeedMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1.UpdateFeedRequest, com.google.cloud.asset.v1.Feed>
-      getUpdateFeedMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.asset.v1.UpdateFeedRequest, com.google.cloud.asset.v1.Feed>
         getUpdateFeedMethod;
@@ -332,9 +275,7 @@ public final class AssetServiceGrpc {
                       .<com.google.cloud.asset.v1.UpdateFeedRequest, com.google.cloud.asset.v1.Feed>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.asset.v1.AssetService", "UpdateFeed"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateFeed"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -350,26 +291,18 @@ public final class AssetServiceGrpc {
     return getUpdateFeedMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteFeedMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1.DeleteFeedRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_FEED = getDeleteFeedMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1.DeleteFeedRequest, com.google.protobuf.Empty>
       getDeleteFeedMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteFeed",
+      requestType = com.google.cloud.asset.v1.DeleteFeedRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1.DeleteFeedRequest, com.google.protobuf.Empty>
       getDeleteFeedMethod() {
-    return getDeleteFeedMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1.DeleteFeedRequest, com.google.protobuf.Empty>
-      getDeleteFeedMethodHelper() {
     io.grpc.MethodDescriptor<com.google.cloud.asset.v1.DeleteFeedRequest, com.google.protobuf.Empty>
         getDeleteFeedMethod;
     if ((getDeleteFeedMethod = AssetServiceGrpc.getDeleteFeedMethod) == null) {
@@ -381,9 +314,7 @@ public final class AssetServiceGrpc {
                       .<com.google.cloud.asset.v1.DeleteFeedRequest, com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.asset.v1.AssetService", "DeleteFeed"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteFeed"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -401,19 +332,43 @@ public final class AssetServiceGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static AssetServiceStub newStub(io.grpc.Channel channel) {
-    return new AssetServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AssetServiceStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AssetServiceStub>() {
+          @java.lang.Override
+          public AssetServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AssetServiceStub(channel, callOptions);
+          }
+        };
+    return AssetServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static AssetServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new AssetServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AssetServiceBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AssetServiceBlockingStub>() {
+          @java.lang.Override
+          public AssetServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AssetServiceBlockingStub(channel, callOptions);
+          }
+        };
+    return AssetServiceBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static AssetServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new AssetServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AssetServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AssetServiceFutureStub>() {
+          @java.lang.Override
+          public AssetServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AssetServiceFutureStub(channel, callOptions);
+          }
+        };
+    return AssetServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -438,7 +393,7 @@ public final class AssetServiceGrpc {
     public void exportAssets(
         com.google.cloud.asset.v1.ExportAssetsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getExportAssetsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getExportAssetsMethod(), responseObserver);
     }
 
     /**
@@ -458,7 +413,7 @@ public final class AssetServiceGrpc {
         com.google.cloud.asset.v1.BatchGetAssetsHistoryRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1.BatchGetAssetsHistoryResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchGetAssetsHistoryMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchGetAssetsHistoryMethod(), responseObserver);
     }
 
     /**
@@ -472,7 +427,7 @@ public final class AssetServiceGrpc {
     public void createFeed(
         com.google.cloud.asset.v1.CreateFeedRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1.Feed> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateFeedMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateFeedMethod(), responseObserver);
     }
 
     /**
@@ -485,7 +440,7 @@ public final class AssetServiceGrpc {
     public void getFeed(
         com.google.cloud.asset.v1.GetFeedRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1.Feed> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetFeedMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetFeedMethod(), responseObserver);
     }
 
     /**
@@ -498,7 +453,7 @@ public final class AssetServiceGrpc {
     public void listFeeds(
         com.google.cloud.asset.v1.ListFeedsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1.ListFeedsResponse> responseObserver) {
-      asyncUnimplementedUnaryCall(getListFeedsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListFeedsMethod(), responseObserver);
     }
 
     /**
@@ -511,7 +466,7 @@ public final class AssetServiceGrpc {
     public void updateFeed(
         com.google.cloud.asset.v1.UpdateFeedRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1.Feed> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateFeedMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateFeedMethod(), responseObserver);
     }
 
     /**
@@ -524,51 +479,51 @@ public final class AssetServiceGrpc {
     public void deleteFeed(
         com.google.cloud.asset.v1.DeleteFeedRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteFeedMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteFeedMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getExportAssetsMethodHelper(),
+              getExportAssetsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.asset.v1.ExportAssetsRequest,
                       com.google.longrunning.Operation>(this, METHODID_EXPORT_ASSETS)))
           .addMethod(
-              getBatchGetAssetsHistoryMethodHelper(),
+              getBatchGetAssetsHistoryMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.asset.v1.BatchGetAssetsHistoryRequest,
                       com.google.cloud.asset.v1.BatchGetAssetsHistoryResponse>(
                       this, METHODID_BATCH_GET_ASSETS_HISTORY)))
           .addMethod(
-              getCreateFeedMethodHelper(),
+              getCreateFeedMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.asset.v1.CreateFeedRequest, com.google.cloud.asset.v1.Feed>(
                       this, METHODID_CREATE_FEED)))
           .addMethod(
-              getGetFeedMethodHelper(),
+              getGetFeedMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.asset.v1.GetFeedRequest, com.google.cloud.asset.v1.Feed>(
                       this, METHODID_GET_FEED)))
           .addMethod(
-              getListFeedsMethodHelper(),
+              getListFeedsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.asset.v1.ListFeedsRequest,
                       com.google.cloud.asset.v1.ListFeedsResponse>(this, METHODID_LIST_FEEDS)))
           .addMethod(
-              getUpdateFeedMethodHelper(),
+              getUpdateFeedMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.asset.v1.UpdateFeedRequest, com.google.cloud.asset.v1.Feed>(
                       this, METHODID_UPDATE_FEED)))
           .addMethod(
-              getDeleteFeedMethodHelper(),
+              getDeleteFeedMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.asset.v1.DeleteFeedRequest, com.google.protobuf.Empty>(
@@ -584,11 +539,8 @@ public final class AssetServiceGrpc {
    * Asset service definition.
    * </pre>
    */
-  public static final class AssetServiceStub extends io.grpc.stub.AbstractStub<AssetServiceStub> {
-    private AssetServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class AssetServiceStub
+      extends io.grpc.stub.AbstractAsyncStub<AssetServiceStub> {
     private AssetServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -612,7 +564,7 @@ public final class AssetServiceGrpc {
         com.google.cloud.asset.v1.ExportAssetsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getExportAssetsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getExportAssetsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -635,7 +587,7 @@ public final class AssetServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1.BatchGetAssetsHistoryResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchGetAssetsHistoryMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchGetAssetsHistoryMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -652,9 +604,7 @@ public final class AssetServiceGrpc {
         com.google.cloud.asset.v1.CreateFeedRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1.Feed> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateFeedMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getCreateFeedMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -668,9 +618,7 @@ public final class AssetServiceGrpc {
         com.google.cloud.asset.v1.GetFeedRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1.Feed> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetFeedMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetFeedMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -684,9 +632,7 @@ public final class AssetServiceGrpc {
         com.google.cloud.asset.v1.ListFeedsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1.ListFeedsResponse> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListFeedsMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getListFeedsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -700,9 +646,7 @@ public final class AssetServiceGrpc {
         com.google.cloud.asset.v1.UpdateFeedRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1.Feed> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateFeedMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getUpdateFeedMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -716,9 +660,7 @@ public final class AssetServiceGrpc {
         com.google.cloud.asset.v1.DeleteFeedRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteFeedMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getDeleteFeedMethod(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -730,11 +672,7 @@ public final class AssetServiceGrpc {
    * </pre>
    */
   public static final class AssetServiceBlockingStub
-      extends io.grpc.stub.AbstractStub<AssetServiceBlockingStub> {
-    private AssetServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<AssetServiceBlockingStub> {
     private AssetServiceBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -757,8 +695,7 @@ public final class AssetServiceGrpc {
      */
     public com.google.longrunning.Operation exportAssets(
         com.google.cloud.asset.v1.ExportAssetsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getExportAssetsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getExportAssetsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -777,7 +714,7 @@ public final class AssetServiceGrpc {
     public com.google.cloud.asset.v1.BatchGetAssetsHistoryResponse batchGetAssetsHistory(
         com.google.cloud.asset.v1.BatchGetAssetsHistoryRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchGetAssetsHistoryMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchGetAssetsHistoryMethod(), getCallOptions(), request);
     }
 
     /**
@@ -790,8 +727,7 @@ public final class AssetServiceGrpc {
      */
     public com.google.cloud.asset.v1.Feed createFeed(
         com.google.cloud.asset.v1.CreateFeedRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateFeedMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateFeedMethod(), getCallOptions(), request);
     }
 
     /**
@@ -803,7 +739,7 @@ public final class AssetServiceGrpc {
      */
     public com.google.cloud.asset.v1.Feed getFeed(
         com.google.cloud.asset.v1.GetFeedRequest request) {
-      return blockingUnaryCall(getChannel(), getGetFeedMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetFeedMethod(), getCallOptions(), request);
     }
 
     /**
@@ -815,7 +751,7 @@ public final class AssetServiceGrpc {
      */
     public com.google.cloud.asset.v1.ListFeedsResponse listFeeds(
         com.google.cloud.asset.v1.ListFeedsRequest request) {
-      return blockingUnaryCall(getChannel(), getListFeedsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListFeedsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -827,8 +763,7 @@ public final class AssetServiceGrpc {
      */
     public com.google.cloud.asset.v1.Feed updateFeed(
         com.google.cloud.asset.v1.UpdateFeedRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateFeedMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateFeedMethod(), getCallOptions(), request);
     }
 
     /**
@@ -840,8 +775,7 @@ public final class AssetServiceGrpc {
      */
     public com.google.protobuf.Empty deleteFeed(
         com.google.cloud.asset.v1.DeleteFeedRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteFeedMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteFeedMethod(), getCallOptions(), request);
     }
   }
 
@@ -853,11 +787,7 @@ public final class AssetServiceGrpc {
    * </pre>
    */
   public static final class AssetServiceFutureStub
-      extends io.grpc.stub.AbstractStub<AssetServiceFutureStub> {
-    private AssetServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<AssetServiceFutureStub> {
     private AssetServiceFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -881,7 +811,7 @@ public final class AssetServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         exportAssets(com.google.cloud.asset.v1.ExportAssetsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getExportAssetsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getExportAssetsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -901,7 +831,7 @@ public final class AssetServiceGrpc {
             com.google.cloud.asset.v1.BatchGetAssetsHistoryResponse>
         batchGetAssetsHistory(com.google.cloud.asset.v1.BatchGetAssetsHistoryRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchGetAssetsHistoryMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchGetAssetsHistoryMethod(), getCallOptions()), request);
     }
 
     /**
@@ -915,7 +845,7 @@ public final class AssetServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.asset.v1.Feed>
         createFeed(com.google.cloud.asset.v1.CreateFeedRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateFeedMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateFeedMethod(), getCallOptions()), request);
     }
 
     /**
@@ -927,8 +857,7 @@ public final class AssetServiceGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.asset.v1.Feed>
         getFeed(com.google.cloud.asset.v1.GetFeedRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetFeedMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getGetFeedMethod(), getCallOptions()), request);
     }
 
     /**
@@ -941,8 +870,7 @@ public final class AssetServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.asset.v1.ListFeedsResponse>
         listFeeds(com.google.cloud.asset.v1.ListFeedsRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getListFeedsMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getListFeedsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -955,7 +883,7 @@ public final class AssetServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.asset.v1.Feed>
         updateFeed(com.google.cloud.asset.v1.UpdateFeedRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateFeedMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateFeedMethod(), getCallOptions()), request);
     }
 
     /**
@@ -968,7 +896,7 @@ public final class AssetServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> deleteFeed(
         com.google.cloud.asset.v1.DeleteFeedRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteFeedMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteFeedMethod(), getCallOptions()), request);
     }
   }
 
@@ -1098,13 +1026,13 @@ public final class AssetServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new AssetServiceFileDescriptorSupplier())
-                      .addMethod(getExportAssetsMethodHelper())
-                      .addMethod(getBatchGetAssetsHistoryMethodHelper())
-                      .addMethod(getCreateFeedMethodHelper())
-                      .addMethod(getGetFeedMethodHelper())
-                      .addMethod(getListFeedsMethodHelper())
-                      .addMethod(getUpdateFeedMethodHelper())
-                      .addMethod(getDeleteFeedMethodHelper())
+                      .addMethod(getExportAssetsMethod())
+                      .addMethod(getBatchGetAssetsHistoryMethod())
+                      .addMethod(getCreateFeedMethod())
+                      .addMethod(getGetFeedMethod())
+                      .addMethod(getListFeedsMethod())
+                      .addMethod(getUpdateFeedMethod())
+                      .addMethod(getDeleteFeedMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-asset-v1beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-asset-v1beta1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.1.1 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/asset/v1beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-asset-v1beta1/src/main/java/com/google/cloud/asset/v1beta1/AssetServiceGrpc.java
+++ b/grpc-google-cloud-asset-v1beta1/src/main/java/com/google/cloud/asset/v1beta1/AssetServiceGrpc.java
@@ -30,7 +30,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/asset/v1beta1/asset_service.proto")
 public final class AssetServiceGrpc {
 
@@ -39,26 +39,18 @@ public final class AssetServiceGrpc {
   public static final String SERVICE_NAME = "google.cloud.asset.v1beta1.AssetService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getExportAssetsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1beta1.ExportAssetsRequest, com.google.longrunning.Operation>
-      METHOD_EXPORT_ASSETS = getExportAssetsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1beta1.ExportAssetsRequest, com.google.longrunning.Operation>
       getExportAssetsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ExportAssets",
+      requestType = com.google.cloud.asset.v1beta1.ExportAssetsRequest.class,
+      responseType = com.google.longrunning.Operation.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1beta1.ExportAssetsRequest, com.google.longrunning.Operation>
       getExportAssetsMethod() {
-    return getExportAssetsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1beta1.ExportAssetsRequest, com.google.longrunning.Operation>
-      getExportAssetsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.asset.v1beta1.ExportAssetsRequest, com.google.longrunning.Operation>
         getExportAssetsMethod;
@@ -72,9 +64,7 @@ public final class AssetServiceGrpc {
                           com.google.longrunning.Operation>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.asset.v1beta1.AssetService", "ExportAssets"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ExportAssets"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -91,30 +81,20 @@ public final class AssetServiceGrpc {
     return getExportAssetsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getBatchGetAssetsHistoryMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryRequest,
-          com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryResponse>
-      METHOD_BATCH_GET_ASSETS_HISTORY = getBatchGetAssetsHistoryMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryRequest,
           com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryResponse>
       getBatchGetAssetsHistoryMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "BatchGetAssetsHistory",
+      requestType = com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryRequest.class,
+      responseType = com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryRequest,
           com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryResponse>
       getBatchGetAssetsHistoryMethod() {
-    return getBatchGetAssetsHistoryMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryRequest,
-          com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryResponse>
-      getBatchGetAssetsHistoryMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryRequest,
             com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryResponse>
@@ -132,8 +112,7 @@ public final class AssetServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.asset.v1beta1.AssetService", "BatchGetAssetsHistory"))
+                          generateFullMethodName(SERVICE_NAME, "BatchGetAssetsHistory"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -154,19 +133,43 @@ public final class AssetServiceGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static AssetServiceStub newStub(io.grpc.Channel channel) {
-    return new AssetServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AssetServiceStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AssetServiceStub>() {
+          @java.lang.Override
+          public AssetServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AssetServiceStub(channel, callOptions);
+          }
+        };
+    return AssetServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static AssetServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new AssetServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AssetServiceBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AssetServiceBlockingStub>() {
+          @java.lang.Override
+          public AssetServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AssetServiceBlockingStub(channel, callOptions);
+          }
+        };
+    return AssetServiceBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static AssetServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new AssetServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AssetServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AssetServiceFutureStub>() {
+          @java.lang.Override
+          public AssetServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AssetServiceFutureStub(channel, callOptions);
+          }
+        };
+    return AssetServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -192,7 +195,7 @@ public final class AssetServiceGrpc {
     public void exportAssets(
         com.google.cloud.asset.v1beta1.ExportAssetsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
-      asyncUnimplementedUnaryCall(getExportAssetsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getExportAssetsMethod(), responseObserver);
     }
 
     /**
@@ -212,20 +215,20 @@ public final class AssetServiceGrpc {
         com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getBatchGetAssetsHistoryMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getBatchGetAssetsHistoryMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getExportAssetsMethodHelper(),
+              getExportAssetsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.asset.v1beta1.ExportAssetsRequest,
                       com.google.longrunning.Operation>(this, METHODID_EXPORT_ASSETS)))
           .addMethod(
-              getBatchGetAssetsHistoryMethodHelper(),
+              getBatchGetAssetsHistoryMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryRequest,
@@ -242,11 +245,8 @@ public final class AssetServiceGrpc {
    * Asset service definition.
    * </pre>
    */
-  public static final class AssetServiceStub extends io.grpc.stub.AbstractStub<AssetServiceStub> {
-    private AssetServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class AssetServiceStub
+      extends io.grpc.stub.AbstractAsyncStub<AssetServiceStub> {
     private AssetServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -271,7 +271,7 @@ public final class AssetServiceGrpc {
         com.google.cloud.asset.v1beta1.ExportAssetsRequest request,
         io.grpc.stub.StreamObserver<com.google.longrunning.Operation> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getExportAssetsMethodHelper(), getCallOptions()),
+          getChannel().newCall(getExportAssetsMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -294,7 +294,7 @@ public final class AssetServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getBatchGetAssetsHistoryMethodHelper(), getCallOptions()),
+          getChannel().newCall(getBatchGetAssetsHistoryMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -308,11 +308,7 @@ public final class AssetServiceGrpc {
    * </pre>
    */
   public static final class AssetServiceBlockingStub
-      extends io.grpc.stub.AbstractStub<AssetServiceBlockingStub> {
-    private AssetServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<AssetServiceBlockingStub> {
     private AssetServiceBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -336,8 +332,7 @@ public final class AssetServiceGrpc {
      */
     public com.google.longrunning.Operation exportAssets(
         com.google.cloud.asset.v1beta1.ExportAssetsRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getExportAssetsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getExportAssetsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -356,7 +351,7 @@ public final class AssetServiceGrpc {
     public com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryResponse batchGetAssetsHistory(
         com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryRequest request) {
       return blockingUnaryCall(
-          getChannel(), getBatchGetAssetsHistoryMethodHelper(), getCallOptions(), request);
+          getChannel(), getBatchGetAssetsHistoryMethod(), getCallOptions(), request);
     }
   }
 
@@ -368,11 +363,7 @@ public final class AssetServiceGrpc {
    * </pre>
    */
   public static final class AssetServiceFutureStub
-      extends io.grpc.stub.AbstractStub<AssetServiceFutureStub> {
-    private AssetServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<AssetServiceFutureStub> {
     private AssetServiceFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -397,7 +388,7 @@ public final class AssetServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.longrunning.Operation>
         exportAssets(com.google.cloud.asset.v1beta1.ExportAssetsRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getExportAssetsMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getExportAssetsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -417,7 +408,7 @@ public final class AssetServiceGrpc {
             com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryResponse>
         batchGetAssetsHistory(com.google.cloud.asset.v1beta1.BatchGetAssetsHistoryRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getBatchGetAssetsHistoryMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getBatchGetAssetsHistoryMethod(), getCallOptions()), request);
     }
   }
 
@@ -517,8 +508,8 @@ public final class AssetServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new AssetServiceFileDescriptorSupplier())
-                      .addMethod(getExportAssetsMethodHelper())
-                      .addMethod(getBatchGetAssetsHistoryMethodHelper())
+                      .addMethod(getExportAssetsMethod())
+                      .addMethod(getBatchGetAssetsHistoryMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-asset-v1p1beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-asset-v1p1beta1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.1.1 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/asset/v1p1beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-asset-v1p1beta1/src/main/java/com/google/cloud/asset/v1p1beta1/AssetServiceGrpc.java
+++ b/grpc-google-cloud-asset-v1p1beta1/src/main/java/com/google/cloud/asset/v1p1beta1/AssetServiceGrpc.java
@@ -30,7 +30,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/asset/v1p1beta1/asset_service.proto")
 public final class AssetServiceGrpc {
 
@@ -39,30 +39,20 @@ public final class AssetServiceGrpc {
   public static final String SERVICE_NAME = "google.cloud.asset.v1p1beta1.AssetService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSearchAllResourcesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1p1beta1.SearchAllResourcesRequest,
-          com.google.cloud.asset.v1p1beta1.SearchAllResourcesResponse>
-      METHOD_SEARCH_ALL_RESOURCES = getSearchAllResourcesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1p1beta1.SearchAllResourcesRequest,
           com.google.cloud.asset.v1p1beta1.SearchAllResourcesResponse>
       getSearchAllResourcesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SearchAllResources",
+      requestType = com.google.cloud.asset.v1p1beta1.SearchAllResourcesRequest.class,
+      responseType = com.google.cloud.asset.v1p1beta1.SearchAllResourcesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1p1beta1.SearchAllResourcesRequest,
           com.google.cloud.asset.v1p1beta1.SearchAllResourcesResponse>
       getSearchAllResourcesMethod() {
-    return getSearchAllResourcesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1p1beta1.SearchAllResourcesRequest,
-          com.google.cloud.asset.v1p1beta1.SearchAllResourcesResponse>
-      getSearchAllResourcesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.asset.v1p1beta1.SearchAllResourcesRequest,
             com.google.cloud.asset.v1p1beta1.SearchAllResourcesResponse>
@@ -77,9 +67,7 @@ public final class AssetServiceGrpc {
                           com.google.cloud.asset.v1p1beta1.SearchAllResourcesResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.asset.v1p1beta1.AssetService", "SearchAllResources"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "SearchAllResources"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -98,30 +86,20 @@ public final class AssetServiceGrpc {
     return getSearchAllResourcesMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getSearchAllIamPoliciesMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesRequest,
-          com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesResponse>
-      METHOD_SEARCH_ALL_IAM_POLICIES = getSearchAllIamPoliciesMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesRequest,
           com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesResponse>
       getSearchAllIamPoliciesMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "SearchAllIamPolicies",
+      requestType = com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesRequest.class,
+      responseType = com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesRequest,
           com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesResponse>
       getSearchAllIamPoliciesMethod() {
-    return getSearchAllIamPoliciesMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesRequest,
-          com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesResponse>
-      getSearchAllIamPoliciesMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesRequest,
             com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesResponse>
@@ -138,8 +116,7 @@ public final class AssetServiceGrpc {
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
                       .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.asset.v1p1beta1.AssetService", "SearchAllIamPolicies"))
+                          generateFullMethodName(SERVICE_NAME, "SearchAllIamPolicies"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -160,19 +137,43 @@ public final class AssetServiceGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static AssetServiceStub newStub(io.grpc.Channel channel) {
-    return new AssetServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AssetServiceStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AssetServiceStub>() {
+          @java.lang.Override
+          public AssetServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AssetServiceStub(channel, callOptions);
+          }
+        };
+    return AssetServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static AssetServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new AssetServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AssetServiceBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AssetServiceBlockingStub>() {
+          @java.lang.Override
+          public AssetServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AssetServiceBlockingStub(channel, callOptions);
+          }
+        };
+    return AssetServiceBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static AssetServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new AssetServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AssetServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AssetServiceFutureStub>() {
+          @java.lang.Override
+          public AssetServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AssetServiceFutureStub(channel, callOptions);
+          }
+        };
+    return AssetServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -200,7 +201,7 @@ public final class AssetServiceGrpc {
         com.google.cloud.asset.v1p1beta1.SearchAllResourcesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1p1beta1.SearchAllResourcesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getSearchAllResourcesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSearchAllResourcesMethod(), responseObserver);
     }
 
     /**
@@ -219,21 +220,21 @@ public final class AssetServiceGrpc {
         com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getSearchAllIamPoliciesMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getSearchAllIamPoliciesMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getSearchAllResourcesMethodHelper(),
+              getSearchAllResourcesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.asset.v1p1beta1.SearchAllResourcesRequest,
                       com.google.cloud.asset.v1p1beta1.SearchAllResourcesResponse>(
                       this, METHODID_SEARCH_ALL_RESOURCES)))
           .addMethod(
-              getSearchAllIamPoliciesMethodHelper(),
+              getSearchAllIamPoliciesMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesRequest,
@@ -250,11 +251,8 @@ public final class AssetServiceGrpc {
    * Asset service definition.
    * </pre>
    */
-  public static final class AssetServiceStub extends io.grpc.stub.AbstractStub<AssetServiceStub> {
-    private AssetServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class AssetServiceStub
+      extends io.grpc.stub.AbstractAsyncStub<AssetServiceStub> {
     private AssetServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -281,7 +279,7 @@ public final class AssetServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1p1beta1.SearchAllResourcesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSearchAllResourcesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getSearchAllResourcesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -303,7 +301,7 @@ public final class AssetServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getSearchAllIamPoliciesMethodHelper(), getCallOptions()),
+          getChannel().newCall(getSearchAllIamPoliciesMethod(), getCallOptions()),
           request,
           responseObserver);
     }
@@ -317,11 +315,7 @@ public final class AssetServiceGrpc {
    * </pre>
    */
   public static final class AssetServiceBlockingStub
-      extends io.grpc.stub.AbstractStub<AssetServiceBlockingStub> {
-    private AssetServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<AssetServiceBlockingStub> {
     private AssetServiceBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -347,7 +341,7 @@ public final class AssetServiceGrpc {
     public com.google.cloud.asset.v1p1beta1.SearchAllResourcesResponse searchAllResources(
         com.google.cloud.asset.v1p1beta1.SearchAllResourcesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getSearchAllResourcesMethodHelper(), getCallOptions(), request);
+          getChannel(), getSearchAllResourcesMethod(), getCallOptions(), request);
     }
 
     /**
@@ -365,7 +359,7 @@ public final class AssetServiceGrpc {
     public com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesResponse searchAllIamPolicies(
         com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesRequest request) {
       return blockingUnaryCall(
-          getChannel(), getSearchAllIamPoliciesMethodHelper(), getCallOptions(), request);
+          getChannel(), getSearchAllIamPoliciesMethod(), getCallOptions(), request);
     }
   }
 
@@ -377,11 +371,7 @@ public final class AssetServiceGrpc {
    * </pre>
    */
   public static final class AssetServiceFutureStub
-      extends io.grpc.stub.AbstractStub<AssetServiceFutureStub> {
-    private AssetServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<AssetServiceFutureStub> {
     private AssetServiceFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -408,7 +398,7 @@ public final class AssetServiceGrpc {
             com.google.cloud.asset.v1p1beta1.SearchAllResourcesResponse>
         searchAllResources(com.google.cloud.asset.v1p1beta1.SearchAllResourcesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getSearchAllResourcesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getSearchAllResourcesMethod(), getCallOptions()), request);
     }
 
     /**
@@ -427,7 +417,7 @@ public final class AssetServiceGrpc {
             com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesResponse>
         searchAllIamPolicies(com.google.cloud.asset.v1p1beta1.SearchAllIamPoliciesRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getSearchAllIamPoliciesMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getSearchAllIamPoliciesMethod(), getCallOptions()), request);
     }
   }
 
@@ -529,8 +519,8 @@ public final class AssetServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new AssetServiceFileDescriptorSupplier())
-                      .addMethod(getSearchAllResourcesMethodHelper())
-                      .addMethod(getSearchAllIamPoliciesMethodHelper())
+                      .addMethod(getSearchAllResourcesMethod())
+                      .addMethod(getSearchAllIamPoliciesMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-asset-v1p2beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-asset-v1p2beta1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.1.1 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/asset/v1p2beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/grpc-google-cloud-asset-v1p2beta1/src/main/java/com/google/cloud/asset/v1p2beta1/AssetServiceGrpc.java
+++ b/grpc-google-cloud-asset-v1p2beta1/src/main/java/com/google/cloud/asset/v1p2beta1/AssetServiceGrpc.java
@@ -30,7 +30,7 @@ import static io.grpc.stub.ServerCalls.asyncUnimplementedUnaryCall;
  * </pre>
  */
 @javax.annotation.Generated(
-    value = "by gRPC proto compiler (version 1.10.0)",
+    value = "by gRPC proto compiler",
     comments = "Source: google/cloud/asset/v1p2beta1/asset_service.proto")
 public final class AssetServiceGrpc {
 
@@ -39,26 +39,18 @@ public final class AssetServiceGrpc {
   public static final String SERVICE_NAME = "google.cloud.asset.v1p2beta1.AssetService";
 
   // Static method descriptors that strictly reflect the proto.
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getCreateFeedMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1p2beta1.CreateFeedRequest, com.google.cloud.asset.v1p2beta1.Feed>
-      METHOD_CREATE_FEED = getCreateFeedMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1p2beta1.CreateFeedRequest, com.google.cloud.asset.v1p2beta1.Feed>
       getCreateFeedMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "CreateFeed",
+      requestType = com.google.cloud.asset.v1p2beta1.CreateFeedRequest.class,
+      responseType = com.google.cloud.asset.v1p2beta1.Feed.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1p2beta1.CreateFeedRequest, com.google.cloud.asset.v1p2beta1.Feed>
       getCreateFeedMethod() {
-    return getCreateFeedMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1p2beta1.CreateFeedRequest, com.google.cloud.asset.v1p2beta1.Feed>
-      getCreateFeedMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.asset.v1p2beta1.CreateFeedRequest,
             com.google.cloud.asset.v1p2beta1.Feed>
@@ -73,9 +65,7 @@ public final class AssetServiceGrpc {
                           com.google.cloud.asset.v1p2beta1.Feed>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.asset.v1p2beta1.AssetService", "CreateFeed"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "CreateFeed"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -92,26 +82,18 @@ public final class AssetServiceGrpc {
     return getCreateFeedMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getGetFeedMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1p2beta1.GetFeedRequest, com.google.cloud.asset.v1p2beta1.Feed>
-      METHOD_GET_FEED = getGetFeedMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1p2beta1.GetFeedRequest, com.google.cloud.asset.v1p2beta1.Feed>
       getGetFeedMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "GetFeed",
+      requestType = com.google.cloud.asset.v1p2beta1.GetFeedRequest.class,
+      responseType = com.google.cloud.asset.v1p2beta1.Feed.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1p2beta1.GetFeedRequest, com.google.cloud.asset.v1p2beta1.Feed>
       getGetFeedMethod() {
-    return getGetFeedMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1p2beta1.GetFeedRequest, com.google.cloud.asset.v1p2beta1.Feed>
-      getGetFeedMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.asset.v1p2beta1.GetFeedRequest, com.google.cloud.asset.v1p2beta1.Feed>
         getGetFeedMethod;
@@ -125,9 +107,7 @@ public final class AssetServiceGrpc {
                           com.google.cloud.asset.v1p2beta1.Feed>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.asset.v1p2beta1.AssetService", "GetFeed"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "GetFeed"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -143,30 +123,20 @@ public final class AssetServiceGrpc {
     return getGetFeedMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getListFeedsMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1p2beta1.ListFeedsRequest,
-          com.google.cloud.asset.v1p2beta1.ListFeedsResponse>
-      METHOD_LIST_FEEDS = getListFeedsMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1p2beta1.ListFeedsRequest,
           com.google.cloud.asset.v1p2beta1.ListFeedsResponse>
       getListFeedsMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "ListFeeds",
+      requestType = com.google.cloud.asset.v1p2beta1.ListFeedsRequest.class,
+      responseType = com.google.cloud.asset.v1p2beta1.ListFeedsResponse.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1p2beta1.ListFeedsRequest,
           com.google.cloud.asset.v1p2beta1.ListFeedsResponse>
       getListFeedsMethod() {
-    return getListFeedsMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1p2beta1.ListFeedsRequest,
-          com.google.cloud.asset.v1p2beta1.ListFeedsResponse>
-      getListFeedsMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.asset.v1p2beta1.ListFeedsRequest,
             com.google.cloud.asset.v1p2beta1.ListFeedsResponse>
@@ -181,9 +151,7 @@ public final class AssetServiceGrpc {
                           com.google.cloud.asset.v1p2beta1.ListFeedsResponse>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.asset.v1p2beta1.AssetService", "ListFeeds"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "ListFeeds"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -201,26 +169,18 @@ public final class AssetServiceGrpc {
     return getListFeedsMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getUpdateFeedMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1p2beta1.UpdateFeedRequest, com.google.cloud.asset.v1p2beta1.Feed>
-      METHOD_UPDATE_FEED = getUpdateFeedMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1p2beta1.UpdateFeedRequest, com.google.cloud.asset.v1p2beta1.Feed>
       getUpdateFeedMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "UpdateFeed",
+      requestType = com.google.cloud.asset.v1p2beta1.UpdateFeedRequest.class,
+      responseType = com.google.cloud.asset.v1p2beta1.Feed.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1p2beta1.UpdateFeedRequest, com.google.cloud.asset.v1p2beta1.Feed>
       getUpdateFeedMethod() {
-    return getUpdateFeedMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1p2beta1.UpdateFeedRequest, com.google.cloud.asset.v1p2beta1.Feed>
-      getUpdateFeedMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.asset.v1p2beta1.UpdateFeedRequest,
             com.google.cloud.asset.v1p2beta1.Feed>
@@ -235,9 +195,7 @@ public final class AssetServiceGrpc {
                           com.google.cloud.asset.v1p2beta1.Feed>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.asset.v1p2beta1.AssetService", "UpdateFeed"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "UpdateFeed"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -254,26 +212,18 @@ public final class AssetServiceGrpc {
     return getUpdateFeedMethod;
   }
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
-  @java.lang.Deprecated // Use {@link #getDeleteFeedMethod()} instead.
-  public static final io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1p2beta1.DeleteFeedRequest, com.google.protobuf.Empty>
-      METHOD_DELETE_FEED = getDeleteFeedMethodHelper();
-
   private static volatile io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1p2beta1.DeleteFeedRequest, com.google.protobuf.Empty>
       getDeleteFeedMethod;
 
-  @io.grpc.ExperimentalApi("https://github.com/grpc/grpc-java/issues/1901")
+  @io.grpc.stub.annotations.RpcMethod(
+      fullMethodName = SERVICE_NAME + '/' + "DeleteFeed",
+      requestType = com.google.cloud.asset.v1p2beta1.DeleteFeedRequest.class,
+      responseType = com.google.protobuf.Empty.class,
+      methodType = io.grpc.MethodDescriptor.MethodType.UNARY)
   public static io.grpc.MethodDescriptor<
           com.google.cloud.asset.v1p2beta1.DeleteFeedRequest, com.google.protobuf.Empty>
       getDeleteFeedMethod() {
-    return getDeleteFeedMethodHelper();
-  }
-
-  private static io.grpc.MethodDescriptor<
-          com.google.cloud.asset.v1p2beta1.DeleteFeedRequest, com.google.protobuf.Empty>
-      getDeleteFeedMethodHelper() {
     io.grpc.MethodDescriptor<
             com.google.cloud.asset.v1p2beta1.DeleteFeedRequest, com.google.protobuf.Empty>
         getDeleteFeedMethod;
@@ -287,9 +237,7 @@ public final class AssetServiceGrpc {
                           com.google.protobuf.Empty>
                           newBuilder()
                       .setType(io.grpc.MethodDescriptor.MethodType.UNARY)
-                      .setFullMethodName(
-                          generateFullMethodName(
-                              "google.cloud.asset.v1p2beta1.AssetService", "DeleteFeed"))
+                      .setFullMethodName(generateFullMethodName(SERVICE_NAME, "DeleteFeed"))
                       .setSampledToLocalTracing(true)
                       .setRequestMarshaller(
                           io.grpc.protobuf.ProtoUtils.marshaller(
@@ -308,19 +256,43 @@ public final class AssetServiceGrpc {
 
   /** Creates a new async stub that supports all call types for the service */
   public static AssetServiceStub newStub(io.grpc.Channel channel) {
-    return new AssetServiceStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AssetServiceStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AssetServiceStub>() {
+          @java.lang.Override
+          public AssetServiceStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AssetServiceStub(channel, callOptions);
+          }
+        };
+    return AssetServiceStub.newStub(factory, channel);
   }
 
   /**
    * Creates a new blocking-style stub that supports unary and streaming output calls on the service
    */
   public static AssetServiceBlockingStub newBlockingStub(io.grpc.Channel channel) {
-    return new AssetServiceBlockingStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AssetServiceBlockingStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AssetServiceBlockingStub>() {
+          @java.lang.Override
+          public AssetServiceBlockingStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AssetServiceBlockingStub(channel, callOptions);
+          }
+        };
+    return AssetServiceBlockingStub.newStub(factory, channel);
   }
 
   /** Creates a new ListenableFuture-style stub that supports unary calls on the service */
   public static AssetServiceFutureStub newFutureStub(io.grpc.Channel channel) {
-    return new AssetServiceFutureStub(channel);
+    io.grpc.stub.AbstractStub.StubFactory<AssetServiceFutureStub> factory =
+        new io.grpc.stub.AbstractStub.StubFactory<AssetServiceFutureStub>() {
+          @java.lang.Override
+          public AssetServiceFutureStub newStub(
+              io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
+            return new AssetServiceFutureStub(channel, callOptions);
+          }
+        };
+    return AssetServiceFutureStub.newStub(factory, channel);
   }
 
   /**
@@ -343,7 +315,7 @@ public final class AssetServiceGrpc {
     public void createFeed(
         com.google.cloud.asset.v1p2beta1.CreateFeedRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1p2beta1.Feed> responseObserver) {
-      asyncUnimplementedUnaryCall(getCreateFeedMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getCreateFeedMethod(), responseObserver);
     }
 
     /**
@@ -356,7 +328,7 @@ public final class AssetServiceGrpc {
     public void getFeed(
         com.google.cloud.asset.v1p2beta1.GetFeedRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1p2beta1.Feed> responseObserver) {
-      asyncUnimplementedUnaryCall(getGetFeedMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getGetFeedMethod(), responseObserver);
     }
 
     /**
@@ -370,7 +342,7 @@ public final class AssetServiceGrpc {
         com.google.cloud.asset.v1p2beta1.ListFeedsRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1p2beta1.ListFeedsResponse>
             responseObserver) {
-      asyncUnimplementedUnaryCall(getListFeedsMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getListFeedsMethod(), responseObserver);
     }
 
     /**
@@ -383,7 +355,7 @@ public final class AssetServiceGrpc {
     public void updateFeed(
         com.google.cloud.asset.v1p2beta1.UpdateFeedRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1p2beta1.Feed> responseObserver) {
-      asyncUnimplementedUnaryCall(getUpdateFeedMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getUpdateFeedMethod(), responseObserver);
     }
 
     /**
@@ -396,39 +368,39 @@ public final class AssetServiceGrpc {
     public void deleteFeed(
         com.google.cloud.asset.v1p2beta1.DeleteFeedRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
-      asyncUnimplementedUnaryCall(getDeleteFeedMethodHelper(), responseObserver);
+      asyncUnimplementedUnaryCall(getDeleteFeedMethod(), responseObserver);
     }
 
     @java.lang.Override
     public final io.grpc.ServerServiceDefinition bindService() {
       return io.grpc.ServerServiceDefinition.builder(getServiceDescriptor())
           .addMethod(
-              getCreateFeedMethodHelper(),
+              getCreateFeedMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.asset.v1p2beta1.CreateFeedRequest,
                       com.google.cloud.asset.v1p2beta1.Feed>(this, METHODID_CREATE_FEED)))
           .addMethod(
-              getGetFeedMethodHelper(),
+              getGetFeedMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.asset.v1p2beta1.GetFeedRequest,
                       com.google.cloud.asset.v1p2beta1.Feed>(this, METHODID_GET_FEED)))
           .addMethod(
-              getListFeedsMethodHelper(),
+              getListFeedsMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.asset.v1p2beta1.ListFeedsRequest,
                       com.google.cloud.asset.v1p2beta1.ListFeedsResponse>(
                       this, METHODID_LIST_FEEDS)))
           .addMethod(
-              getUpdateFeedMethodHelper(),
+              getUpdateFeedMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.asset.v1p2beta1.UpdateFeedRequest,
                       com.google.cloud.asset.v1p2beta1.Feed>(this, METHODID_UPDATE_FEED)))
           .addMethod(
-              getDeleteFeedMethodHelper(),
+              getDeleteFeedMethod(),
               asyncUnaryCall(
                   new MethodHandlers<
                       com.google.cloud.asset.v1p2beta1.DeleteFeedRequest,
@@ -444,11 +416,8 @@ public final class AssetServiceGrpc {
    * Asset service definition.
    * </pre>
    */
-  public static final class AssetServiceStub extends io.grpc.stub.AbstractStub<AssetServiceStub> {
-    private AssetServiceStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+  public static final class AssetServiceStub
+      extends io.grpc.stub.AbstractAsyncStub<AssetServiceStub> {
     private AssetServiceStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -470,9 +439,7 @@ public final class AssetServiceGrpc {
         com.google.cloud.asset.v1p2beta1.CreateFeedRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1p2beta1.Feed> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getCreateFeedMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getCreateFeedMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -486,9 +453,7 @@ public final class AssetServiceGrpc {
         com.google.cloud.asset.v1p2beta1.GetFeedRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1p2beta1.Feed> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getGetFeedMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getGetFeedMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -503,9 +468,7 @@ public final class AssetServiceGrpc {
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1p2beta1.ListFeedsResponse>
             responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getListFeedsMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getListFeedsMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -519,9 +482,7 @@ public final class AssetServiceGrpc {
         com.google.cloud.asset.v1p2beta1.UpdateFeedRequest request,
         io.grpc.stub.StreamObserver<com.google.cloud.asset.v1p2beta1.Feed> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getUpdateFeedMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getUpdateFeedMethod(), getCallOptions()), request, responseObserver);
     }
 
     /**
@@ -535,9 +496,7 @@ public final class AssetServiceGrpc {
         com.google.cloud.asset.v1p2beta1.DeleteFeedRequest request,
         io.grpc.stub.StreamObserver<com.google.protobuf.Empty> responseObserver) {
       asyncUnaryCall(
-          getChannel().newCall(getDeleteFeedMethodHelper(), getCallOptions()),
-          request,
-          responseObserver);
+          getChannel().newCall(getDeleteFeedMethod(), getCallOptions()), request, responseObserver);
     }
   }
 
@@ -549,11 +508,7 @@ public final class AssetServiceGrpc {
    * </pre>
    */
   public static final class AssetServiceBlockingStub
-      extends io.grpc.stub.AbstractStub<AssetServiceBlockingStub> {
-    private AssetServiceBlockingStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractBlockingStub<AssetServiceBlockingStub> {
     private AssetServiceBlockingStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -574,8 +529,7 @@ public final class AssetServiceGrpc {
      */
     public com.google.cloud.asset.v1p2beta1.Feed createFeed(
         com.google.cloud.asset.v1p2beta1.CreateFeedRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getCreateFeedMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getCreateFeedMethod(), getCallOptions(), request);
     }
 
     /**
@@ -587,7 +541,7 @@ public final class AssetServiceGrpc {
      */
     public com.google.cloud.asset.v1p2beta1.Feed getFeed(
         com.google.cloud.asset.v1p2beta1.GetFeedRequest request) {
-      return blockingUnaryCall(getChannel(), getGetFeedMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getGetFeedMethod(), getCallOptions(), request);
     }
 
     /**
@@ -599,7 +553,7 @@ public final class AssetServiceGrpc {
      */
     public com.google.cloud.asset.v1p2beta1.ListFeedsResponse listFeeds(
         com.google.cloud.asset.v1p2beta1.ListFeedsRequest request) {
-      return blockingUnaryCall(getChannel(), getListFeedsMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getListFeedsMethod(), getCallOptions(), request);
     }
 
     /**
@@ -611,8 +565,7 @@ public final class AssetServiceGrpc {
      */
     public com.google.cloud.asset.v1p2beta1.Feed updateFeed(
         com.google.cloud.asset.v1p2beta1.UpdateFeedRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getUpdateFeedMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getUpdateFeedMethod(), getCallOptions(), request);
     }
 
     /**
@@ -624,8 +577,7 @@ public final class AssetServiceGrpc {
      */
     public com.google.protobuf.Empty deleteFeed(
         com.google.cloud.asset.v1p2beta1.DeleteFeedRequest request) {
-      return blockingUnaryCall(
-          getChannel(), getDeleteFeedMethodHelper(), getCallOptions(), request);
+      return blockingUnaryCall(getChannel(), getDeleteFeedMethod(), getCallOptions(), request);
     }
   }
 
@@ -637,11 +589,7 @@ public final class AssetServiceGrpc {
    * </pre>
    */
   public static final class AssetServiceFutureStub
-      extends io.grpc.stub.AbstractStub<AssetServiceFutureStub> {
-    private AssetServiceFutureStub(io.grpc.Channel channel) {
-      super(channel);
-    }
-
+      extends io.grpc.stub.AbstractFutureStub<AssetServiceFutureStub> {
     private AssetServiceFutureStub(io.grpc.Channel channel, io.grpc.CallOptions callOptions) {
       super(channel, callOptions);
     }
@@ -663,7 +611,7 @@ public final class AssetServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.asset.v1p2beta1.Feed>
         createFeed(com.google.cloud.asset.v1p2beta1.CreateFeedRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getCreateFeedMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getCreateFeedMethod(), getCallOptions()), request);
     }
 
     /**
@@ -675,8 +623,7 @@ public final class AssetServiceGrpc {
      */
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.asset.v1p2beta1.Feed>
         getFeed(com.google.cloud.asset.v1p2beta1.GetFeedRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getGetFeedMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getGetFeedMethod(), getCallOptions()), request);
     }
 
     /**
@@ -689,8 +636,7 @@ public final class AssetServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<
             com.google.cloud.asset.v1p2beta1.ListFeedsResponse>
         listFeeds(com.google.cloud.asset.v1p2beta1.ListFeedsRequest request) {
-      return futureUnaryCall(
-          getChannel().newCall(getListFeedsMethodHelper(), getCallOptions()), request);
+      return futureUnaryCall(getChannel().newCall(getListFeedsMethod(), getCallOptions()), request);
     }
 
     /**
@@ -703,7 +649,7 @@ public final class AssetServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.cloud.asset.v1p2beta1.Feed>
         updateFeed(com.google.cloud.asset.v1p2beta1.UpdateFeedRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getUpdateFeedMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getUpdateFeedMethod(), getCallOptions()), request);
     }
 
     /**
@@ -716,7 +662,7 @@ public final class AssetServiceGrpc {
     public com.google.common.util.concurrent.ListenableFuture<com.google.protobuf.Empty> deleteFeed(
         com.google.cloud.asset.v1p2beta1.DeleteFeedRequest request) {
       return futureUnaryCall(
-          getChannel().newCall(getDeleteFeedMethodHelper(), getCallOptions()), request);
+          getChannel().newCall(getDeleteFeedMethod(), getCallOptions()), request);
     }
   }
 
@@ -836,11 +782,11 @@ public final class AssetServiceGrpc {
               result =
                   io.grpc.ServiceDescriptor.newBuilder(SERVICE_NAME)
                       .setSchemaDescriptor(new AssetServiceFileDescriptorSupplier())
-                      .addMethod(getCreateFeedMethodHelper())
-                      .addMethod(getGetFeedMethodHelper())
-                      .addMethod(getListFeedsMethodHelper())
-                      .addMethod(getUpdateFeedMethodHelper())
-                      .addMethod(getDeleteFeedMethodHelper())
+                      .addMethod(getCreateFeedMethod())
+                      .addMethod(getGetFeedMethod())
+                      .addMethod(getListFeedsMethod())
+                      .addMethod(getUpdateFeedMethod())
+                      .addMethod(getDeleteFeedMethod())
                       .build();
         }
       }

--- a/grpc-google-cloud-asset-v1p4beta1/clirr-ignored-differences.xml
+++ b/grpc-google-cloud-asset-v1p4beta1/clirr-ignored-differences.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- see http://www.mojohaus.org/clirr-maven-plugin/examples/ignored-differences.html -->
+<differences>
+  <difference>
+    <!-- TODO: remove after 1.1.1 released -->
+    <differenceType>6001</differenceType>
+    <className>com/google/cloud/asset/v1p4beta1/*Grpc</className>
+    <field>METHOD_*</field>
+  </difference>
+</differences>

--- a/synth.py
+++ b/synth.py
@@ -14,38 +14,18 @@
 
 """This script is used to synthesize generated parts of this library."""
 
-import synthtool as s
-import synthtool.gcp as gcp
 import synthtool.languages.java as java
 
 AUTOSYNTH_MULTIPLE_COMMITS = True
 
-gapic = gcp.GAPICGenerator()
-
 service = 'asset'
-versions = ['v1', 'v1beta1', 'v1p2beta1']
-config_pattern = '/google/cloud/asset/artman_cloudasset_{version}.yaml'
+versions = ['v1', 'v1beta1', 'v1p2beta1', 'v1p1beta1', 'v1p4beta1']
 
 for version in versions:
-  java.gapic_library(
+  library = java.bazel_library(
       service=service,
       version=version,
-      config_pattern='/google/cloud/asset/artman_cloudasset_{version}.yaml',
-      package_pattern='com.google.cloud.{service}.{version}',
-      gapic=gapic,
+      bazel_target=f'//google/cloud/{service}/{version}:google-cloud-{service}-{version}-java',
   )
-
-java.gapic_library(
-    service=service,
-    version='v1p1beta1',
-    config_pattern='/google/cloud/asset/{version}/artman_cloudasset_{version}.yaml',
-    package_pattern='com.google.cloud.{service}.{version}',
-    gapic=gapic,
-)
-
-java.bazel_library(
-    service=service,
-    version='v1p4beta1',
-)
 
 java.common_templates()


### PR DESCRIPTION
The changes in grpc stubs are caused by the gRPC upgrade from 1.10 (more than a year old) to 1.27 (same version which is used as runtime dependency)

