### PR TITLE
samples: migrate samples from GoogleCloudPlatform/java-docs-samples /asset/cloud-client

### DIFF
--- a/samples/snippets/src/main/java/com/example/asset/ListAssetsExample.java
+++ b/samples/snippets/src/main/java/com/example/asset/ListAssetsExample.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.asset;
+
+// [START asset_quickstart_list_assets]
+// Imports the Google Cloud client library
+
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.asset.v1.ProjectName;
+import com.google.cloud.asset.v1p5beta1.AssetServiceClient;
+import com.google.cloud.asset.v1p5beta1.AssetServiceClient.ListAssetsPagedResponse;
+import com.google.cloud.asset.v1p5beta1.ContentType;
+import com.google.cloud.asset.v1p5beta1.ListAssetsRequest;
+import java.util.Arrays;
+
+public class ListAssetsExample {
+
+  public static void listAssets() throws Exception {
+    // The project id of the asset parent to list.
+    String projectId = "YOUR_PROJECT_ID";
+    // The asset types to list. E.g.,
+    // ["storage.googleapis.com/Bucket", "bigquery.googleapis.com/Table"].
+    // See full list of supported asset types at
+    // https://cloud.google.com/asset-inventory/docs/supported-asset-types.
+    String[] assetTypes = {"YOUR_ASSET_TYPES_TO_LIST"};
+    // The asset content type to list. E.g., ContentType.CONTENT_TYPE_UNSPECIFIED.
+    // See full list of content types at
+    // https://cloud.google.com/asset-inventory/docs/reference/rpc/google.cloud.asset.v1p5beta1#contenttype
+    ContentType contentType = ContentType.CONTENT_TYPE_UNSPECIFIED;
+    listAssets(projectId, assetTypes, contentType);
+  }
+
+  public static void listAssets(String projectId, String[] assetTypes, ContentType contentType)
+      throws Exception {
+    try (AssetServiceClient client = AssetServiceClient.create()) {
+      ProjectName parent = ProjectName.of(projectId);
+
+      // Build initial ListAssetsRequest without setting page token.
+      ListAssetsRequest request = ListAssetsRequest.newBuilder()
+          .setParent(parent.toString())
+          .addAllAssetTypes(Arrays.asList(assetTypes))
+          .setContentType(contentType)
+          .build();
+
+      // Repeatedly call ListAssets until page token is empty.
+      ListAssetsPagedResponse response = client.listAssets(request);
+      System.out.println(response);
+      while (!response.getNextPageToken().isEmpty()) {
+        request = request.toBuilder()
+            .setPageToken(response.getNextPageToken()).build();
+        response = client.listAssets(request);
+        System.out.println(response);
+      }
+    }
+  }
+}
+// [END asset_quickstart_list_assets]

--- a/samples/snippets/src/test/java/com/example/asset/ListAssets.java
+++ b/samples/snippets/src/test/java/com/example/asset/ListAssets.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.example.asset;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.cloud.ServiceOptions;
+import com.google.cloud.asset.v1p5beta1.ContentType;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.UUID;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for list assets sample. */
+@RunWith(JUnit4.class)
+@SuppressWarnings("checkstyle:abbreviationaswordinname")
+public class ListAssets {
+  private ByteArrayOutputStream bout;
+
+  @Before
+  public void setUp() {
+    bout = new ByteArrayOutputStream();
+    System.setOut(new PrintStream(bout));
+  }
+
+  @After
+  public void tearDown() {
+    System.setOut(null);
+    bout.reset();
+  }
+
+  @Test
+  public void testListAssetsExample() throws Exception {
+    // Use the default project Id (configure it by setting environment variable
+    // "GOOGLE_CLOUD_PROJECT").
+    String projectId = ServiceOptions.getDefaultProjectId();
+    String[] assetTypes = {"storage.googleapis.com/Bucket", "bigquery.googleapis.com/Table"};
+    ContentType contentType = ContentType.CONTENT_TYPE_UNSPECIFIED;
+    ListAssetsExample.listAssets(projectId, assetTypes, contentType);
+    String got = bout.toString();
+    if (!got.isEmpty()) {
+      assertThat(got).contains("asset");
+    }
+  }
+}


### PR DESCRIPTION
Migrates missed sample which was created between migration to java-asset and deletion in GoogleCloudPlatform/java-docs-samples