### PR TITLE
build: testing Yoshi Approver account token

### DIFF
--- a/.github/workflows/auto-release.yaml
+++ b/.github/workflows/auto-release.yaml
@@ -7,7 +7,7 @@ jobs:
     steps:
     - uses: actions/github-script@v3.0.0
       with:
-        github-token: ${{secrets.GITHUB_TOKEN}}
+        github-token: ${{secrets.YOSHI_APPROVER_TOKEN}}
         debug: true
         script: |
           // only approve PRs from release-please[bot]


### PR DESCRIPTION
We are going to turn on required CODEOWNER reviews. We need to use an account rather than github-actions token.
