### PR TITLE
fix: close out todo for 2.0.0

### DIFF
--- a/proto-google-cloud-asset-v1/clirr-ignored-differences.xml
+++ b/proto-google-cloud-asset-v1/clirr-ignored-differences.xml
@@ -16,18 +16,4 @@
     <className>com/google/cloud/asset/v1/*OrBuilder</className>
     <method>boolean has*(*)</method>
   </difference>
-
-  <!-- TODO: remove after 2.0.0 released -->
-  <difference>
-    <differenceType>8001</differenceType>
-    <className>com/google/cloud/asset/v1/IamPolicyAnalysis*</className>
-  </difference>
-  <difference>
-    <differenceType>8001</differenceType>
-    <className>com/google/cloud/asset/v1/ExportIamPolicyAnalysis*</className>
-  </difference>
-  <difference>
-    <differenceType>8001</differenceType>
-    <className>com/google/cloud/asset/v1/AnalyzeIamPolicy*</className>
-  </difference>
 </differences>


### PR DESCRIPTION
@chingor13 we only check against the previous release so after a couple of releases the exclusions can be removed. 