### PR TITLE
ci: removing linkage-monitor from the required checks

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -10,7 +10,6 @@ branchProtectionRules:
     requiredStatusCheckContexts:
       - dependencies (8)
       - dependencies (11)
-      - linkage-monitor
       - lint
       - clirr
       - units (8)
@@ -26,7 +25,6 @@ branchProtectionRules:
     requiredStatusCheckContexts:
       - dependencies (8)
       - dependencies (11)
-      - linkage-monitor
       - lint
       - clirr
       - units (7)
@@ -53,7 +51,6 @@ branchProtectionRules:
   requiredStatusCheckContexts:
     - "dependencies (8)"
     - "dependencies (11)"
-    - "linkage-monitor"
     - "lint"
     - "clirr"
     - "units (8)"

--- a/README.md
+++ b/README.md
@@ -57,13 +57,13 @@ compile 'com.google.cloud:google-cloud-asset'
 If you are using Gradle without BOM, add this to your dependencies
 
 ```Groovy
-compile 'com.google.cloud:google-cloud-asset:3.0.0'
+compile 'com.google.cloud:google-cloud-asset:3.0.1'
 ```
 
 If you are using SBT, add this to your dependencies
 
 ```Scala
-libraryDependencies += "com.google.cloud" % "google-cloud-asset" % "3.0.0"
+libraryDependencies += "com.google.cloud" % "google-cloud-asset" % "3.0.1"
 ```
 
 ## Authentication


### PR DESCRIPTION
Linkage Monitor is no longer needed, because the Libraries BOM synchronizes with Google Cloud BOM and the shared dependencies BOM https://github.com/GoogleCloudPlatform/cloud-opensource-java/issues/2137