### PR TITLE
fix: Exclude a few dependencies from dependency check.

### DIFF
--- a/.kokoro/dependencies.sh
+++ b/.kokoro/dependencies.sh
@@ -66,11 +66,11 @@ function completenessCheck() {
   # This is stripped from the output as it is not present in the flattened pom.
   # Only dependencies with 'compile' or 'runtime' scope are included from original dependency list.
   msg "Generating dependency list using original pom..."
-  mvn dependency:list -f pom.xml -DincludeScope=runtime -DexcludeArtifactIds=commons-codec,commons-logging,annotations,animal-sniffer-annotations,protobuf-java-util,bcprov-jdk15on -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' | sed -e 's/ --.*//' >.org-list.txt
+  mvn dependency:list -f pom.xml -DincludeScope=runtime -DexcludeArtifactIds=commons-codec,commons-logging,annotations,animal-sniffer-annotations,protobuf-java-util,bcprov-jdk15on,grpc-services,re2j,opencensus-proto,bcpkix-jdk15on -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' | sed -e 's/ --.*//' >.org-list.txt
 
   # Output dep list generated using the flattened pom (only 'compile' and 'runtime' scopes)
   msg "Generating dependency list using flattened pom..."
-  mvn dependency:list -f .flattened-pom.xml -DincludeScope=runtime -DexcludeArtifactIds=commons-codec,commons-logging,annotations,animal-sniffer-annotations,protobuf-java-util,bcprov-jdk15on -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' >.new-list.txt
+  mvn dependency:list -f .flattened-pom.xml -DincludeScope=runtime -DexcludeArtifactIds=commons-codec,commons-logging,annotations,animal-sniffer-annotations,protobuf-java-util,bcprov-jdk15on,grpc-services,re2j,opencensus-proto,bcpkix-jdk15on -Dsort=true | grep '\[INFO]    .*:.*:.*:.*:.*' >.new-list.txt
 
   # Compare two dependency lists
   msg "Comparing dependency lists..."


### PR DESCRIPTION
Exclude the following dependencies from dependency check since they are now test dependencies brought in transitively by `java-pubsub`. 

grpc-services,
re2j,
opencensus-proto,
bcpkix-jdk15on