### PR TITLE
ci: clirr is not required

### DIFF
--- a/.github/sync-repo-settings.yaml
+++ b/.github/sync-repo-settings.yaml
@@ -11,7 +11,6 @@ branchProtectionRules:
       - dependencies (8)
       - dependencies (11)
       - lint
-      - clirr
       - units (8)
       - units (11)
       - 'Kokoro - Test: Integration'
@@ -28,7 +27,6 @@ branchProtectionRules:
       - dependencies (8)
       - dependencies (11)
       - lint
-      - clirr
       - units (7)
       - units (8)
       - units (11)


### PR DESCRIPTION
CLIRR check is no longer required.